### PR TITLE
Tech Update 8-4-16

### DIFF
--- a/relativity/common/technology/engineering_mineral_processing.txt
+++ b/relativity/common/technology/engineering_mineral_processing.txt
@@ -124,7 +124,7 @@ tech_mineral_processing_1 = {
 	}
 	
 	ai_weight = {
-		factor = 3
+		factor = 10
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -177,7 +177,7 @@ tech_mineral_processing_2 = {
 	}
 	
 	ai_weight = {
-		factor = 3
+		factor = 10
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -230,7 +230,7 @@ tech_mineral_processing_3 = {
 	}
 	
 	ai_weight = {
-		factor = 3
+		factor = 10
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -283,7 +283,7 @@ tech_mineral_processing_4 = {
 	}
 	
 	ai_weight = {
-		factor = 3
+		factor = 10
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -336,7 +336,7 @@ tech_mineral_processing_5 = {
 	}
 	
 	ai_weight = {
-		factor = 3
+		factor = 10
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -389,7 +389,7 @@ tech_mineral_processing_6 = {
 	}
 	
 	ai_weight = {
-		factor = 3
+		factor = 7
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -442,7 +442,7 @@ tech_mineral_processing_7 = {
 	}
 	
 	ai_weight = {
-		factor = 3
+		factor = 7
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -491,7 +491,7 @@ tech_mineral_processing_8 = {
 	}
 	
 	ai_weight = {
-		factor = 3
+		factor = 7
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -539,7 +539,7 @@ tech_mineral_processing_9 = {
 	}
 	
 	ai_weight = {
-		factor = 3
+		factor = 7
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -588,7 +588,7 @@ tech_mineral_processing_10 = {
 	}
 	
 	ai_weight = {
-		factor = 3
+		factor = 7
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -638,7 +638,7 @@ tech_mineral_processing_11 = {
 	}
 	
 	ai_weight = {
-		factor = 3
+		factor = 5
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -687,7 +687,7 @@ tech_mineral_processing_12 = {
 	}
 	
 	ai_weight = {
-		factor = 3
+		factor = 5
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -736,7 +736,7 @@ tech_mineral_processing_13 = {
 	}
 	
 	ai_weight = {
-		factor = 3
+		factor = 5
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -785,7 +785,7 @@ tech_mineral_processing_14 = {
 	}
 	
 	ai_weight = {
-		factor = 3
+		factor = 5
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -834,7 +834,7 @@ tech_mineral_processing_15 = {
 	}
 	
 	ai_weight = {
-		factor = 3
+		factor = 5
 		modifier = {
 			factor = 1.25
 			research_leader = {

--- a/relativity/common/technology/engineering_terraforming.txt
+++ b/relativity/common/technology/engineering_terraforming.txt
@@ -102,12 +102,12 @@
 ####################
 
 tech_tb_mountain_range = {
-	cost = @tier1cost2
+	cost = @tier2cost2
 	area = engineering
 	tier = 1
 	category = { terraforming }
 	prerequisites = { "tech_colonization_2" }
-	weight = @tier1weight2
+	weight = @tier2weight2
 	
 	weight_groups = {
 		tile_blockers
@@ -179,12 +179,12 @@ tech_tb_mountain_range = {
 }
 
 tech_tb_volcano = {
-	cost = @tier1cost2
+	cost = @tier2cost3
 	area = engineering
 	tier = 1
 	category = { terraforming }
 	prerequisites = { "tech_colonization_3" }
-	weight = @tier1weight2
+	weight = @tier2weight3
 	
 	weight_groups = {
 		tile_blockers
@@ -257,12 +257,12 @@ tech_tb_volcano = {
 }
 
 tech_tb_dangerous_wildlife = {
-	cost = @tier1cost2
+	cost = @tier2cost1
 	area = engineering
 	tier = 1
 	category = { terraforming }
 	prerequisites = { "tech_colonization_1" }
-	weight = @tier1weight2
+	weight = @tier2weight1
 	
 	weight_groups = {
 		tile_blockers
@@ -334,12 +334,12 @@ tech_tb_dangerous_wildlife = {
 }
 
 tech_tb_dense_jungle = {
-	cost = @tier1cost2
+	cost = @tier2cost1
 	area = engineering
 	tier = 1
 	category = { terraforming }
 	prerequisites = { "tech_colonization_1" }
-	weight = @tier1weight2
+	weight = @tier2weight1
 	
 	weight_groups = {
 		tile_blockers
@@ -411,12 +411,12 @@ tech_tb_dense_jungle = {
 }
 
 tech_tb_quicksand_basin = {
-	cost = @tier1cost2
+	cost = @tier2cost1
 	area = engineering
 	tier = 1
 	category = { terraforming }
 	prerequisites = { "tech_colonization_2" }
-	weight = @tier1weight2
+	weight = @tier2weight1
 	
 	weight_groups = {
 		tile_blockers
@@ -488,12 +488,12 @@ tech_tb_quicksand_basin = {
 }
 
 tech_tb_noxious_swamp = {
-	cost = @tier1cost2
+	cost = @tier2cost2
 	area = engineering
 	tier = 1
 	category = { terraforming }
 	prerequisites = { "tech_colonization_2" }
-	weight = @tier1weight2
+	weight = @tier2weight2
 	
 	weight_groups = {
 		tile_blockers
@@ -565,12 +565,12 @@ tech_tb_noxious_swamp = {
 }
 
 tech_tb_massive_glacier = {
-	cost = @tier1cost2
+	cost = @tier2cost3
 	area = engineering
 	tier = 1
 	category = { terraforming }
 	prerequisites = { "tech_colonization_3" }
-	weight = @tier1weight2
+	weight = @tier2weight3
 	
 	weight_groups = {
 		tile_blockers
@@ -642,12 +642,12 @@ tech_tb_massive_glacier = {
 }
 
 tech_tb_toxic_kelp = {
-	cost = @tier1cost2
+	cost = @tier2cost3
 	area = engineering
 	tier = 1
 	category = { terraforming }
 	prerequisites = { "tech_colonization_1" }
-	weight = @tier1weight2
+	weight = @tier2weight3
 	
 	weight_groups = {
 		tile_blockers
@@ -719,12 +719,12 @@ tech_tb_toxic_kelp = {
 }
 
 tech_tb_deep_sinkhole = {
-	cost = @tier1cost2
+	cost = @tier2cost2
 	area = engineering
 	tier = 1
 	category = { terraforming }
 	prerequisites = { "tech_colonization_3" }
-	weight = @tier1weight2
+	weight = @tier2weight2
 	
 	weight_groups = {
 		tile_blockers

--- a/relativity/common/technology/physics_ballistics.txt
+++ b/relativity/common/technology/physics_ballistics.txt
@@ -137,6 +137,16 @@ tech_mass_drivers_1 = {
 				has_trait = "leader_trait_expertise_ballistics"
 			}
 		}
+		modifier = {
+			factor = 0.5
+			AND = {
+			years_passed = 20
+			OR = {
+			has_technology = tech_missiles_1
+			has_technology = tech_lasers_1
+			}
+			}
+		}
 	}
 	
 	ai_weight = {

--- a/relativity/common/technology/physics_particles.txt
+++ b/relativity/common/technology/physics_particles.txt
@@ -136,6 +136,16 @@ tech_lasers_1 = {
 				has_trait = "leader_trait_expertise_particles"
 			}
 		}
+		modifier = {
+			factor = 0.5
+			AND = {
+			years_passed = 20
+			OR = {
+			has_technology = tech_missiles_1
+			has_technology = tech_mass_drivers_1
+			}
+			}
+		}
 	}
 	
 	ai_weight = {

--- a/relativity/common/technology/physics_reactors.txt
+++ b/relativity/common/technology/physics_reactors.txt
@@ -112,12 +112,12 @@ tech_fission_power = {
 
 tech_fusion_power = {
 	area = physics
-	cost = @tier1cost3
+	cost = @tier2cost1
 	tier = 1
 	category = { reactors }
 	ai_update_type = military	
 	prerequisites = { "tech_fission_power" }
-	weight = @tier1weight3
+	weight = @tier2weight1
 	
 	modifier = {
 		max_energy = 250
@@ -148,12 +148,12 @@ tech_fusion_power = {
 
 tech_cold_fusion_power = {
 	area = physics
-	cost = @tier2cost3
+	cost = @tier3cost1
 	tier = 2
 	category = { reactors }
 	ai_update_type = military
 	prerequisites = { "tech_fusion_power" }
-	weight = @tier2weight3
+	weight = @tier3weight1
 	
 	modifier = {
 		max_energy = 250
@@ -184,12 +184,12 @@ tech_cold_fusion_power = {
 
 tech_antimatter_power = {
 	area = physics
-	cost = @tier3cost3
+	cost = @tier4cost1
 	tier = 3
 	category = { reactors }
 	ai_update_type = military	
 	prerequisites = { "tech_cold_fusion_power" }
-	weight = @tier3weight3
+	weight = @tier4weight1
 
 	modifier = {
 		max_energy = 250
@@ -220,12 +220,12 @@ tech_antimatter_power = {
 
 tech_zero_point_power = {
 	area = physics
-	cost = @tier4cost2
+	cost = @tier5cost1
 	tier = 4
 	category = { reactors }
 	ai_update_type = military	
 	prerequisites = { "tech_antimatter_power" }
-	weight = @tier4weight2
+	weight = @tier5weight1
 	
 	modifier = {
 		max_energy = 250

--- a/relativity/common/technology/physics_rocketry.txt
+++ b/relativity/common/technology/physics_rocketry.txt
@@ -135,6 +135,16 @@ tech_missiles_1 = {
 				has_trait = "leader_trait_expertise_rocketry"
 			}
 		}
+		modifier = {
+			factor = 0.5
+			AND = {
+			years_passed = 20
+			OR = {
+			has_technology = tech_lasers_1
+			has_technology = tech_mass_drivers_1
+			}
+			}
+		}
 	}
 	
 	ai_weight = {

--- a/relativity/common/technology/society_military_theory.txt
+++ b/relativity/common/technology/society_military_theory.txt
@@ -887,10 +887,10 @@ tech_military_supremacy = {
 
 tech_military_theory_14 = {
 	area = society
-	cost = @tier4cost2
+	cost = @tier4cost1
 	tier = 4
 	category = { military_theory }
-	weight = @tier4weight2
+	weight = @tier4weight1
 	prerequisites = { "tech_military_supremacy" }
 	
 	modifier = {
@@ -938,11 +938,11 @@ tech_military_theory_14 = {
 
 tech_military_theory_15 = {
 	area = society
-	cost = @tier4cost3
+	cost = @tier4cost2
 	tier = 4
 	category = { military_theory }
 	prerequisites = { "tech_military_theory_14" }
-	weight = @tier4weight3
+	weight = @tier4weight2
 
 	modifier = {
 		navy_size_mult = 0.02
@@ -989,11 +989,11 @@ tech_military_theory_15 = {
 
 tech_military_theory_16 = {
 	area = society
-	cost = @tier4cost4
+	cost = @tier4cost2
 	tier = 4
 	category = { military_theory }
-	prerequisites = { "tech_military_theory_16" }
-	weight = @tier4weight4
+	prerequisites = { "tech_military_theory_15" }
+	weight = @tier4weight2
 
 	modifier = {
 		navy_size_mult = 0.02
@@ -1040,11 +1040,11 @@ tech_military_theory_16 = {
 
 tech_military_theory_17 = {
 	area = society
-	cost = @tier5cost1
-	tier = 5
+	cost = @tier4cost3
+	tier = 4
 	category = { military_theory }
-	prerequisites = { "tech_military_theory_17" }	
-	weight = @tier5weight1
+	prerequisites = { "tech_military_theory_16" }	
+	weight = @tier4weight3
 
 	modifier = {
 		navy_size_mult = 0.02
@@ -1091,11 +1091,11 @@ tech_military_theory_17 = {
 
 tech_military_theory_18 = {
 	area = society
-	cost = @tier5cost2
-	tier = 5
+	cost = @tier4cost3
+	tier = 4
 	category = { military_theory }
-	prerequisites = { "tech_military_theory_18" }	
-	weight = @tier5weight2
+	prerequisites = { "tech_military_theory_17" }	
+	weight = @tier4weight3
 
 	modifier = {
 		navy_size_mult = 0.02
@@ -1142,11 +1142,11 @@ tech_military_theory_18 = {
 
 tech_military_theory_19 = {
 	area = society
-	cost = @tier5cost3
-	tier = 5
+	cost = @tier4cost4
+	tier = 4
 	category = { military_theory }
-	prerequisites = { "tech_military_theory_19" }
-	weight = @tier5weight3
+	prerequisites = { "tech_military_theory_18" }
+	weight = @tier4weight4
 
 	modifier = {
 		navy_size_mult = 0.02
@@ -1193,11 +1193,11 @@ tech_military_theory_19 = {
 
 tech_military_theory_20 = {
 	area = society
-	cost = @tier5cost4
+	cost = @tier5cost1
 	tier = 5
 	category = { military_theory }
-	prerequisites = { "tech_military_theory_20" }	
-	weight = @tier5weight4
+	prerequisites = { "tech_military_theory_19" }	
+	weight = @tier5weight1
 
 	modifier = {
 		navy_size_mult = 0.02


### PR DESCRIPTION
-AI Weights for Refinery Tech tripled to help AI economy
-Research Costs for Tile Blocker tech slightly increased, were too easy before
-The other 2 starting weapon branches won't appear so much in the first 20 years to clutter physics research
-Research Costs for Reactors increased to account for no filler tech in between unlocks
-Fixed Research Costs and Prereqs for Military Theory
