### PR TITLE
8/9 Tech Update

### DIFF
--- a/relativity/common/component_templates/00_weapons_critters_cloud.txt
+++ b/relativity/common/component_templates/00_weapons_critters_cloud.txt
@@ -21,7 +21,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 	
 	component_set = "SPACE_CLOUD_WEAPON_1"
-	prerequisites = { "tech_space_cloud_weapon_1" }
+	prerequisites = { "tech_space_cloud_weapon_1" "tech_fusion_power"}
 	cost = @critter_cost_value
 }
 
@@ -37,6 +37,6 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 	
 	component_set = "SPACE_CLOUD_WEAPON_1"
-	prerequisites = { "tech_space_cloud_weapon_1" }
+	prerequisites = { "tech_space_cloud_weapon_1" "tech_fusion_power"}
 	cost = @critter_cost_value
 }

--- a/relativity/common/component_templates/00_weapons_critters_crystals.txt
+++ b/relativity/common/component_templates/00_weapons_critters_crystals.txt
@@ -19,7 +19,7 @@ weapon_component_template = {
 	
 		
 	component_set = "BLUE_CRYSTAL_WEAPON_1"
-	prerequisites = { "tech_blue_crystal_weapon_1" }
+	prerequisites = { "tech_blue_crystal_weapon_1"}
 	
 	cost = @critter_cost_value
 }
@@ -36,7 +36,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 			
 	component_set = "BLUE_CRYSTAL_WEAPON_1"
-	prerequisites = { "tech_blue_crystal_weapon_1" }
+	prerequisites = { "tech_blue_crystal_weapon_1"}
 	cost = @critter_cost_value
 }
 
@@ -68,7 +68,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 			
 	component_set = "GREEN_CRYSTAL_WEAPON_1"
-	prerequisites = { "tech_green_crystal_weapon_1" }
+	prerequisites = { "tech_green_crystal_weapon_1" "tech_fusion_power"}
 	cost = @critter_cost_value
 }
 
@@ -84,7 +84,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 				
 	component_set = "GREEN_CRYSTAL_WEAPON_1"
-	prerequisites = { "tech_green_crystal_weapon_1" }
+	prerequisites = { "tech_green_crystal_weapon_1" "tech_fusion_power"}
 	cost = @critter_cost_value
 }
 
@@ -100,7 +100,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 				
 	component_set = "GREEN_CRYSTAL_WEAPON_1"
-	prerequisites = { "tech_green_crystal_weapon_1" }
+	prerequisites = { "tech_green_crystal_weapon_1" "tech_fusion_power"}
 	cost = @critter_cost_value
 }
 
@@ -116,7 +116,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 				
 	component_set = "YELLOW_CRYSTAL_WEAPON_1"
-	prerequisites = { "tech_yellow_crystal_weapon_1" }
+	prerequisites = { "tech_yellow_crystal_weapon_1" "tech_cold_fusion_power"}
 	cost = @critter_cost_value
 }
 
@@ -132,7 +132,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 				
 	component_set = "YELLOW_CRYSTAL_WEAPON_1"
-	prerequisites = { "tech_yellow_crystal_weapon_1" }
+	prerequisites = { "tech_yellow_crystal_weapon_1" "tech_cold_fusion_power"}
 	cost = @critter_cost_value
 }
 
@@ -148,7 +148,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 				
 	component_set = "YELLOW_CRYSTAL_WEAPON_1"
-	prerequisites = { "tech_yellow_crystal_weapon_1" }
+	prerequisites = { "tech_yellow_crystal_weapon_1" "tech_cold_fusion_power"}
 	cost = @critter_cost_value
 }
 
@@ -164,7 +164,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 				
 	component_set = "RED_CRYSTAL_WEAPON_1"
-	prerequisites = { "tech_red_crystal_weapon_1" }
+	prerequisites = { "tech_red_crystal_weapon_1" "tech_antimatter_power"}
 	cost = @critter_cost_value
 }
 
@@ -180,7 +180,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 				
 	component_set = "RED_CRYSTAL_WEAPON_1"
-	prerequisites = { "tech_red_crystal_weapon_1" }
+	prerequisites = { "tech_red_crystal_weapon_1" "tech_antimatter_power"}
 	cost = @critter_cost_value
 }
 
@@ -196,7 +196,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 				
 	component_set = "RED_CRYSTAL_WEAPON_1"
-	prerequisites = { "tech_red_crystal_weapon_1" }
+	prerequisites = { "tech_red_crystal_weapon_1" "tech_antimatter_power"}
 	cost = @critter_cost_value
 }
 

--- a/relativity/common/component_templates/00_weapons_critters_extradimensional.txt
+++ b/relativity/common/component_templates/00_weapons_critters_extradimensional.txt
@@ -18,7 +18,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 	
 	component_set = "EXTRADIMENSIONAL_1"
-	prerequisites = { "tech_extradimensional_weapon_1" }
+	prerequisites = { "tech_extradimensional_weapon_1" "tech_antimatter_power"}
 	cost = @critter_cost_value
 }
 
@@ -34,7 +34,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 	
 	component_set = "EXTRADIMENSIONAL_1"
-	prerequisites = { "tech_extradimensional_weapon_1" }
+	prerequisites = { "tech_extradimensional_weapon_1" "tech_antimatter_power"}
 	cost = @critter_cost_value
 }
 
@@ -50,7 +50,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 	
 	component_set = "EXTRADIMENSIONAL_1"
-	prerequisites = { "tech_extradimensional_weapon_1" }
+	prerequisites = { "tech_extradimensional_weapon_1" "tech_antimatter_power"}
 	cost = @critter_cost_value
 }
 

--- a/relativity/common/component_templates/00_weapons_critters_space_whale.txt
+++ b/relativity/common/component_templates/00_weapons_critters_space_whale.txt
@@ -21,7 +21,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 		
 	component_set = "SPACE_WHALE_WEAPON_1"
-	prerequisites = { "tech_space_whale_weapon_1" }
+	prerequisites = { "tech_space_whale_weapon_1" "tech_fusion_power"}
 	cost = @critter_cost_value
 }
 
@@ -37,7 +37,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 		
 	component_set = "SPACE_WHALE_WEAPON_1"
-	prerequisites = { "tech_space_whale_weapon_1" }
+	prerequisites = { "tech_space_whale_weapon_1" "tech_fusion_power"}
 	cost = @critter_cost_value
 }
 
@@ -53,7 +53,7 @@ weapon_component_template = {
 	tags = { weapon_type_energy }
 	
 	component_set = "SPACE_WHALE_WEAPON_1"
-	prerequisites = { "tech_space_whale_weapon_1" }
+	prerequisites = { "tech_space_whale_weapon_1" "tech_fusion_power"}
 	
 	cost = @critter_cost_value
 }

--- a/relativity/common/technology/engineering_ai.txt
+++ b/relativity/common/technology/engineering_ai.txt
@@ -452,10 +452,10 @@ tech_synthetic_leaders = {
 tech_administrative_ai = {
 	area = engineering
 	tier = 1
-	cost = @tier1cost1
+	cost = @tier1cost2
 	category = { ai }	
 	prerequisites = { "tech_basic_science_lab_1" }
-	weight = @tier1weight1
+	weight = @tier1weight2
 	
 	modifier = {
 		all_technology_research_speed = 0.05
@@ -652,7 +652,7 @@ tech_sentient_ai = {
 	category = { ai }
 	is_rare = yes
 	is_dangerous = yes
-	prerequisites = { "tech_self_aware_logic" }
+	prerequisites = { "tech_self_aware_logic"}
 	weight = @tier3weight2
 	
 	modifier = {

--- a/relativity/common/technology/engineering_field_manipulation.txt
+++ b/relativity/common/technology/engineering_field_manipulation.txt
@@ -342,7 +342,7 @@ tech_shields_2 = {
 	tier = 2
 	category = { field_manipulation }
 	ai_update_type = military
-	prerequisites = { "tech_field_manipulation_11" }
+	prerequisites = { "tech_field_manipulation_11" "tech_fusion_power"}
 	weight = @tier2weight2
 	
 	modifier = {
@@ -410,7 +410,7 @@ tech_shield_rechargers_1 = {
 	tier = 2
 	category = { field_manipulation }
 	ai_update_type = military	
-	prerequisites = { "tech_shields_2" }
+	prerequisites = { "tech_shields_2"}
 	weight = @tier2weight2
 	
 	weight_modifier = {
@@ -523,65 +523,6 @@ tech_field_manipulation_12 = {
 	}
 }
 
-tech_planetary_shield_generator = {
-	area = engineering
-	cost = @tier2cost4
-	tier = 2
-	category = { field_manipulation }
-	ai_update_type = military	
-	is_rare = yes
-	prerequisites = { "tech_field_manipulation_12" }
-	weight = @tier2weight4
-	
-	weight_modifier = {
-		factor = 0.25
-	}
-	
-	ai_weight = {
-		factor = 2 #good component
-		modifier = {
-			factor = 1.25
-			research_leader = {
-				area = engineering
-				has_trait = "leader_trait_expertise_field_manipulation"
-			}
-		}
-		modifier = {
-			factor = 2
-			OR = {
-			has_trait = "trait_weak"
-			has_trait = "trait_resilient"
-			}
-		}
-		modifier = {
-			factor = 2
-			OR = {
-			has_ethic = "ethic_militarist"
-			has_ai_personality_behaviour = conqueror
-			has_ethic = "ethic_pacifist"		
-			}
-		}
-		modifier = {
-			factor = 2
-			OR = {
-			has_ai_personality = xenophobic_isolationists
-			has_ai_personality = hive_mind
-			has_ai_personality = decadent_hierarchy
-			has_ai_personality = federation_builders
-			}
-		}
-		modifier = {
-			factor = 4
-			has_ethic = "ethic_fanatic_militarist"
-		}
-		modifier = {
-			factor = 0.5
-			has_ethic = "ethic_fanatic_pacifist"
-		}
-	}
-	# unlocks building: planetary shield generator
-}
-
 tech_field_manipulation_13 = {
 	area = engineering
 	cost = @tier3cost1
@@ -645,7 +586,7 @@ tech_shields_3 = {
 	tier = 3
 	category = { field_manipulation }
 	ai_update_type = military
-	prerequisites = { "tech_field_manipulation_13" }
+	prerequisites = { "tech_field_manipulation_13"  "tech_cold_fusion_power"}
 	weight = @tier3weight1
 	
 	modifier = {
@@ -705,6 +646,65 @@ tech_shields_3 = {
 			has_ethic = "ethic_fanatic_pacifist"
 		}
 	}
+}
+
+tech_planetary_shield_generator = {
+	area = engineering
+	cost = @tier2cost4
+	tier = 2
+	category = { field_manipulation }
+	ai_update_type = military	
+	is_rare = yes
+	prerequisites = { "tech_shields_3"}
+	weight = @tier2weight4
+	
+	weight_modifier = {
+		factor = 0.25
+	}
+	
+	ai_weight = {
+		factor = 2 #good component
+		modifier = {
+			factor = 1.25
+			research_leader = {
+				area = engineering
+				has_trait = "leader_trait_expertise_field_manipulation"
+			}
+		}
+		modifier = {
+			factor = 2
+			OR = {
+			has_trait = "trait_weak"
+			has_trait = "trait_resilient"
+			}
+		}
+		modifier = {
+			factor = 2
+			OR = {
+			has_ethic = "ethic_militarist"
+			has_ai_personality_behaviour = conqueror
+			has_ethic = "ethic_pacifist"		
+			}
+		}
+		modifier = {
+			factor = 2
+			OR = {
+			has_ai_personality = xenophobic_isolationists
+			has_ai_personality = hive_mind
+			has_ai_personality = decadent_hierarchy
+			has_ai_personality = federation_builders
+			}
+		}
+		modifier = {
+			factor = 4
+			has_ethic = "ethic_fanatic_militarist"
+		}
+		modifier = {
+			factor = 0.5
+			has_ethic = "ethic_fanatic_pacifist"
+		}
+	}
+	# unlocks building: planetary shield generator
 }
 
 tech_field_manipulation_14 = {
@@ -770,7 +770,7 @@ tech_shield_recharge_aura_1 = {
 	category = { field_manipulation }
 	ai_update_type = military	
 	is_rare = yes
-	prerequisites = { "tech_field_manipulation_14" }
+	prerequisites = { "tech_field_manipulation_14"}
 	weight = @tier3weight2
 	
 	weight_modifier = {
@@ -964,7 +964,7 @@ tech_shields_4 = {
 	tier = 3
 	category = { field_manipulation }
 	ai_update_type = military
-	prerequisites = { "tech_field_manipulation_16" }
+	prerequisites = { "tech_field_manipulation_16" "tech_antimatter_power"}
 	weight = @tier3weight4
 	
 	modifier = {

--- a/relativity/common/technology/engineering_mineral_processing.txt
+++ b/relativity/common/technology/engineering_mineral_processing.txt
@@ -124,7 +124,7 @@ tech_mineral_processing_1 = {
 	}
 	
 	ai_weight = {
-		factor = 10
+		weight = 10000
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -156,12 +156,12 @@ tech_mineral_processing_1 = {
 
 #Advanced Mineral Processing 2
 tech_mineral_processing_2 = {
-	cost = @tier2cost1
+	cost = @tier1cost3
 	area = engineering
-	tier = 2
+	tier = 1
 	category = { mineral_processing }	
 	prerequisites = { "tech_mineral_processing_1" }
-	weight = @tier2weight1
+	weight = @tier1weight3
 		
 	# unlock mineral processing plant 2	
 
@@ -177,7 +177,8 @@ tech_mineral_processing_2 = {
 	}
 	
 	ai_weight = {
-		factor = 10
+		weight = 10000
+		
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -230,7 +231,7 @@ tech_mineral_processing_3 = {
 	}
 	
 	ai_weight = {
-		factor = 10
+		weight = 500
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -283,7 +284,7 @@ tech_mineral_processing_4 = {
 	}
 	
 	ai_weight = {
-		factor = 10
+		factor = 150
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -336,7 +337,7 @@ tech_mineral_processing_5 = {
 	}
 	
 	ai_weight = {
-		factor = 10
+		factor = 150
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -389,7 +390,7 @@ tech_mineral_processing_6 = {
 	}
 	
 	ai_weight = {
-		factor = 7
+		factor = 150
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -442,7 +443,7 @@ tech_mineral_processing_7 = {
 	}
 	
 	ai_weight = {
-		factor = 7
+		factor = 150
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -491,7 +492,7 @@ tech_mineral_processing_8 = {
 	}
 	
 	ai_weight = {
-		factor = 7
+		factor = 150
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -539,7 +540,7 @@ tech_mineral_processing_9 = {
 	}
 	
 	ai_weight = {
-		factor = 7
+		factor = 150
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -588,7 +589,7 @@ tech_mineral_processing_10 = {
 	}
 	
 	ai_weight = {
-		factor = 7
+		factor = 150
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -638,7 +639,7 @@ tech_mineral_processing_11 = {
 	}
 	
 	ai_weight = {
-		factor = 5
+		factor = 100
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -687,7 +688,7 @@ tech_mineral_processing_12 = {
 	}
 	
 	ai_weight = {
-		factor = 5
+		factor = 100
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -736,7 +737,7 @@ tech_mineral_processing_13 = {
 	}
 	
 	ai_weight = {
-		factor = 5
+		factor = 100
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -785,7 +786,7 @@ tech_mineral_processing_14 = {
 	}
 	
 	ai_weight = {
-		factor = 5
+		factor = 100
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -834,7 +835,7 @@ tech_mineral_processing_15 = {
 	}
 	
 	ai_weight = {
-		factor = 5
+		factor = 100
 		modifier = {
 			factor = 1.25
 			research_leader = {

--- a/relativity/common/technology/engineering_spaceport_expansion.txt
+++ b/relativity/common/technology/engineering_spaceport_expansion.txt
@@ -169,7 +169,7 @@ tech_spaceport_2 = {
 	}
 	
 	ai_weight = {
-		factor = 100 #important tech - destroyers
+		factor = 90 #important tech - destroyers
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -225,7 +225,7 @@ tech_spaceport_3 = {
 	}
 	
 	ai_weight = {
-		factor = 100 #important tech
+		factor = 90 #important tech
 		modifier = {
 			factor = 1.25
 			research_leader = {
@@ -281,7 +281,7 @@ tech_spaceport_4 = {
 	}
 	
 	ai_weight = {
-		factor = 100 #important tech
+		factor = 90 #important tech
 		modifier = {
 			factor = 1.25
 			research_leader = {

--- a/relativity/common/technology/engineering_thrusters.txt
+++ b/relativity/common/technology/engineering_thrusters.txt
@@ -239,7 +239,7 @@ tech_thrusters_2 = {
 	tier = 2
 	category = { thrusters }
 	ai_update_type = all	
-	prerequisites = { "tech_thrusters_7" }
+	prerequisites = { "tech_thrusters_7" "tech_fusion_power"}
 	weight = @tier2weight2
 	
 	weight_modifier = {
@@ -445,7 +445,7 @@ tech_thrusters_3 = {
 	tier = 3
 	category = { thrusters }
 	ai_update_type = all	
-	prerequisites = { "tech_thrusters_11" }
+	prerequisites = { "tech_thrusters_11" "tech_cold_fusion_power"}
 	weight = @tier3weight2
 	
 	weight_modifier = {
@@ -651,7 +651,7 @@ tech_thrusters_4 = {
 	tier = 3
 	category = { thrusters }
 	ai_update_type = all	
-	prerequisites = { "tech_thrusters_15" }
+	prerequisites = { "tech_thrusters_15" "tech_antimatter_power"}
 	weight = @tier3weight4
 	
 	weight_modifier = {
@@ -856,7 +856,7 @@ tech_thrusters_20 = {
 	tier = 4
 	category = { thrusters }
 	prerequisites = { "tech_thrusters_19"}	
-	weight = @tier2weight4
+	weight = @tier4weight4
 	
 	modifier = {
 		ship_speed_mult = 0.05

--- a/relativity/common/technology/physics_ballistics.txt
+++ b/relativity/common/technology/physics_ballistics.txt
@@ -666,7 +666,7 @@ tech_kinetic_artillery_1 = {
 	tier = 4
 	category = { ballistics }
 	ai_update_type = military	
-	prerequisites = { "tech_ballistics_16" }
+	prerequisites = { "tech_ballistics_16" "tech_cold_fusion_power"}
 	weight = @tier4weight1
 	
 	weight_modifier = {
@@ -790,7 +790,7 @@ tech_kinetic_artillery_2 = {
 	tier = 4
 	category = { ballistics }
 	ai_update_type = military	
-	prerequisites = { "tech_ballistics_17" }
+	prerequisites = { "tech_ballistics_17" "tech_antimatter_power"}
 	weight = @tier4weight3
 	
 	weight_modifier = {

--- a/relativity/common/technology/physics_particles.txt
+++ b/relativity/common/technology/physics_particles.txt
@@ -172,12 +172,12 @@ tech_lasers_1 = {
 # Blue Lasers
 tech_lasers_2 = {
 	area = physics
-	cost = @tier1cost4
-	tier = 1
+	cost = @tier2cost1
+	tier = 2
 	category = { particles }
 	ai_update_type = military
-	prerequisites = { "tech_lasers_1" }
-	weight = @tier1weight4
+	prerequisites = { "tech_lasers_1" "tech_fusion_power"}
+	weight = @tier2weight1
 	
 	weight_modifier = {
 		modifier = {
@@ -246,12 +246,12 @@ tech_lasers_2 = {
 # UV Lasers
 tech_lasers_3 = {
 	area = physics
-	cost = @tier2cost4
-	tier = 2
+	cost = @tier3cost1
+	tier = 3
 	category = { particles }
 	ai_update_type = military	
-	prerequisites = { "tech_lasers_2" }
-	weight = @tier2weight4
+	prerequisites = { "tech_lasers_2" "tech_cold_fusion_power"}
+	weight = @tier3weight1
 	
 	weight_modifier = {
 		modifier = {
@@ -320,12 +320,12 @@ tech_lasers_3 = {
 # X-Ray Lasers
 tech_lasers_4 = {
 	area = physics
-	cost = @tier3cost2
+	cost = @tier3cost3
 	tier = 3
 	category = { particles }
 	ai_update_type = military
 	prerequisites = { "tech_lasers_3" }
-	weight = @tier3weight2
+	weight = @tier3weight3
 	
 	weight_modifier = {
 		modifier = {
@@ -394,12 +394,12 @@ tech_lasers_4 = {
 # Gamma Lasers
 tech_lasers_5 = {
 	area = physics
-	cost = @tier3cost4
-	tier = 3	
+	cost = @tier4cost1
+	tier = 4	
 	category = { particles }
 	ai_update_type = military
-	prerequisites = { "tech_lasers_4" }
-	weight = @tier3weight4
+	prerequisites = { "tech_lasers_4" "tech_antimatter_power"}
+	weight = @tier4weight1
 	
 	weight_modifier = {
 		modifier = {
@@ -471,7 +471,7 @@ tech_energy_lance_1 = {
 	tier = 4
 	category = { particles }
 	ai_update_type = military	
-	prerequisites = { "tech_lasers_5" }
+	prerequisites = { "tech_lasers_5" "tech_antimatter_power"}
 	weight = @tier4weight1
 	
 	weight_modifier = {
@@ -544,7 +544,7 @@ tech_energy_lance_2 = {
 	tier = 4
 	category = { particles }
 	ai_update_type = military
-	prerequisites = { "tech_energy_lance_1" }
+	prerequisites = { "tech_energy_lance_1" "tech_zero_point_power"}
 	weight = @tier4weight3
 	
 	weight_modifier = {
@@ -620,7 +620,7 @@ tech_plasma_1 = {
 	cost = @tier3cost1
 	tier = 3
 	category = { particles }
-	prerequisites = { "tech_lasers_4" }
+	prerequisites = { "tech_lasers_4" "tech_cold_fusion_power"}
 	ai_update_type = military
 	weight = @tier3weight1
 	
@@ -773,7 +773,7 @@ tech_plasma_3 = {
 	tier = 3
 	category = { particles }
 	ai_update_type = military	
-	prerequisites = { "tech_plasma_2" }
+	prerequisites = { "tech_plasma_2" "tech_antimatter_power"}
 	weight = @tier3weight4
 	
 	weight_modifier = {
@@ -921,12 +921,12 @@ tech_arc_emitter_1 = {
 
 tech_arc_emitter_2 = {
 	area = physics
-	cost = @tier4cost3
+	cost = @tier4cost4
 	tier = 4
 	category = { particles }
 	ai_update_type = military	
-	prerequisites = { "tech_arc_emitter_1" }
-	weight = @tier4weight3
+	prerequisites = { "tech_arc_emitter_1" "tech_zero_point_power"}
+	weight = @tier4weight4
 	
 	weight_modifier = {
 		modifier = {
@@ -1001,7 +1001,7 @@ tech_disruptors_1 = {
 	cost = @tier2cost3
 	tier = 2
 	category = { particles }
-	prerequisites = { "tech_lasers_4" }
+	prerequisites = { "tech_lasers_4"}
 	ai_update_type = military
 	weight = @tier2weight3
 	
@@ -1077,12 +1077,12 @@ tech_disruptors_1 = {
 
 tech_disruptors_2 = {
 	area = physics
-	cost = @tier3cost1
+	cost = @tier3cost2
 	tier = 3
 	category = { particles }
 	ai_update_type = military	
 	prerequisites = { "tech_disruptors_1" }
-	weight = @tier3weight1
+	weight = @tier3weight2
 	
 	weight_modifier = {
 		modifier = {
@@ -1154,7 +1154,7 @@ tech_disruptors_3 = {
 	tier = 4
 	category = { particles }
 	ai_update_type = military
-	prerequisites = { "tech_disruptors_2" }
+	prerequisites = { "tech_disruptors_2" "tech_antimatter_power"}
 	weight = @tier4weight1
 	
 	weight_modifier = {
@@ -1231,7 +1231,7 @@ tech_energy_torpedoes_1 = {
 	tier = 3
 	category = { particles }
 	ai_update_type = military	
-	prerequisites = { "tech_disruptors_3" }
+	prerequisites = { "tech_disruptors_2" }
 	weight = @tier3weight1
 	
 	weight_modifier = {
@@ -1310,7 +1310,7 @@ tech_energy_torpedoes_2 = {
 	tier = 4
 	category = { particles }
 	ai_update_type = military	
-	prerequisites = { "tech_energy_torpedoes_1" }
+	prerequisites = { "tech_energy_torpedoes_1" "tech_antimatter_power"}
 	weight = @tier4weight1
 	
 	weight_modifier = {
@@ -1379,11 +1379,11 @@ tech_energy_torpedoes_2 = {
 
 tech_lasers_18 = {
 	area = physics
-	cost = @tier4cost3
+	cost = @tier4cost4
 	tier = 4
 	category = { particles }
-	prerequisites = { "tech_energy_torpedoes_2"}	
-	weight = @tier4weight3
+	prerequisites = { "tech_energy_torpedoes_2" "tech_zero_point_power"}	
+	weight = @tier4weight4
 	
 	modifier = {
 		weapon_type_energy_weapon_damage_mult = 0.05
@@ -1430,11 +1430,11 @@ tech_lasers_18 = {
 
 tech_lasers_19 = {
 	area = physics
-	cost = @tier4cost3
+	cost = @tier4cost4
 	tier = 4
 	category = { particles }
 	prerequisites = { "tech_energy_lance_2"}	
-	weight = @tier4weight3
+	weight = @tier4weight4
 	
 	modifier = {
 		weapon_type_energy_weapon_damage_mult = 0.05
@@ -1481,10 +1481,10 @@ tech_lasers_19 = {
 
 tech_lasers_20 = {
 	area = physics
-	cost = @tier4cost3
-	tier = 4
+	cost = @tier5cost1
+	tier = 5
 	prerequisites = { "tech_arc_emitter_2"}	
-	weight = @tier4weight3
+	weight = @tier5weight1
 	
 	modifier = {
 		weapon_type_energy_weapon_damage_mult = 0.05

--- a/relativity/common/technology/physics_power_plants.txt
+++ b/relativity/common/technology/physics_power_plants.txt
@@ -750,11 +750,11 @@ tech_power_plant_14 = {
 
 tech_power_plant_15 = {
 	area = physics
-	cost = @tier5cost2
+	cost = @tier5cost1
 	tier = 5
 	category = { power_plants }
 	prerequisites = { "tech_power_plant_14"}	
-	weight = @tier5weight2
+	weight = @tier5weight1
 	
 	weight_modifier = {
 		modifier = {

--- a/relativity/common/technology/physics_reactors.txt
+++ b/relativity/common/technology/physics_reactors.txt
@@ -113,10 +113,10 @@ tech_fission_power = {
 tech_fusion_power = {
 	area = physics
 	cost = @tier2cost1
-	tier = 1
+	tier = 2
 	category = { reactors }
 	ai_update_type = military	
-	prerequisites = { "tech_fission_power" }
+	prerequisites = { "tech_fission_power" "tech_power_plant_4"}
 	weight = @tier2weight1
 	
 	modifier = {
@@ -148,12 +148,12 @@ tech_fusion_power = {
 
 tech_cold_fusion_power = {
 	area = physics
-	cost = @tier3cost1
+	cost = @tier2cost4
 	tier = 2
 	category = { reactors }
 	ai_update_type = military
-	prerequisites = { "tech_fusion_power" }
-	weight = @tier3weight1
+	prerequisites = { "tech_fusion_power" "tech_power_plant_7"}
+	weight = @tier2weight4
 	
 	modifier = {
 		max_energy = 250
@@ -184,12 +184,12 @@ tech_cold_fusion_power = {
 
 tech_antimatter_power = {
 	area = physics
-	cost = @tier4cost1
+	cost = @tier3cost4
 	tier = 3
 	category = { reactors }
 	ai_update_type = military	
-	prerequisites = { "tech_cold_fusion_power" }
-	weight = @tier4weight1
+	prerequisites = { "tech_cold_fusion_power" "tech_power_plant_10"}
+	weight = @tier3weight4
 
 	modifier = {
 		max_energy = 250
@@ -220,12 +220,12 @@ tech_antimatter_power = {
 
 tech_zero_point_power = {
 	area = physics
-	cost = @tier5cost1
+	cost = @tier4cost4
 	tier = 4
 	category = { reactors }
 	ai_update_type = military	
-	prerequisites = { "tech_antimatter_power" }
-	weight = @tier5weight1
+	prerequisites = { "tech_antimatter_power" "tech_power_plant_13"}
+	weight = @tier4weight4
 	
 	modifier = {
 		max_energy = 250

--- a/relativity/common/technology/society_new_worlds.txt
+++ b/relativity/common/technology/society_new_worlds.txt
@@ -106,6 +106,7 @@ tech_colonization_1 = {
 	cost = @tier1cost2
 	area = society
 	tier = 1
+	#start_tech = yes
 	category = { new_worlds }
 	prerequisites = { "tech_spaceport_1" }
 	weight = @tier1weight2
@@ -120,7 +121,7 @@ tech_colonization_1 = {
 	weight_modifier = {
 		factor = 3
 		modifier = {
-			factor = 100
+			factor = 10000
 			is_ai = yes
 		}
 		modifier = {
@@ -149,7 +150,7 @@ tech_colonization_1 = {
 	}
 	
 	ai_weight = {
-		weight = 10000
+		weight = 100000
 	}
 }
 


### PR DESCRIPTION
-Reactors tied to power plant techs (3/Fusion, 7, 10, 13)
-Shield, Lasers, High-Tier Ballistics, Thrusters, and most Xeno Weapons now tied to Reactor unlocks
-Lasers Research costs increased to balance out their current superior DPS
-AI Weights for Colony Ship tech and first few Mineral Processing techs increased
-Admin AI Tech Cost increased slightly
-AI Weight for Spaceports reduced slightly to help it pick more helpful techs early game
