### PR TITLE
9/12 Update

### DIFF
--- a/relativity/common/buildings/00_buildings.txt
+++ b/relativity/common/buildings/00_buildings.txt
@@ -5503,7 +5503,21 @@ building_bank = {
 	
 	#ai_special_building = yes
 	ai_weight = {
-		weight = 60
+		weight = 50
+		modifier = {
+			factor = 2
+			has_country_resource = {
+			type = energy
+			amount < 8
+			}
+		}
+		modifier = {
+			factor = 0
+			has_country_resource = {
+			type = energy
+			amount > 8
+			}
+		}
 #modifier = {
 			 #factor = 0
 			 #tile = {

--- a/relativity/common/defines/00_defines.lua
+++ b/relativity/common/defines/00_defines.lua
@@ -1213,8 +1213,8 @@ NDefines = {
 		
 		INFLUENCE_MAX_STORED_PER_POST = 00,				-- Max stored in any single influence budget post
 		
-		INFLUENCE_BUDGET_STATIONS = 0.35,			-- Fraction of monthly influence that is used on stations (frontier outposts)
-		INFLUENCE_BUDGET_EDICTS = 0.65,				-- Fraction of monthly influence that is used on edicts
+		INFLUENCE_BUDGET_STATIONS = 0.20,			-- Fraction of monthly influence that is used on stations (frontier outposts)
+		INFLUENCE_BUDGET_EDICTS = 0.80,				-- Fraction of monthly influence that is used on edicts
 		INFLUENCE_BUDGET_SAVINGS = 0.0,				-- Fraction of monthly influence that is saved
 
 		THREAT_TRUCE_MONTHS = 12,				-- AI will not consider the opponent a threat if this many months are left on a truce

--- a/relativity/common/edicts/00_edicts.txt
+++ b/relativity/common/edicts/00_edicts.txt
@@ -111,6 +111,15 @@ country_edict = {
 	
 	ai_weight = {
 		weight = 0
+		modifier = {
+			weight = 80
+			AND = {
+				years_passed > 40
+				NOT = {
+					has_technology = tech_void_1
+				}
+			}
+		}
 	}	
 }
 
@@ -135,6 +144,15 @@ country_edict = {
 	
 	ai_weight = {
 		weight = 0
+		modifier = {
+			weight = 80
+			AND = {
+				years_passed > 35
+				NOT = {
+					has_technology = tech_fusion_power
+				}
+			}
+		}
 	}	
 }
 
@@ -166,8 +184,13 @@ country_edict = {
 			}
 		}
 		modifier = {
-			factor = 0
-			has_technology = tech_colonization_1
+			weight = 90
+			AND = {
+				years_passed > 30
+				NOT = {
+					has_technology = tech_adaptive_bureaucracy
+				}
+			}
 		}
 	}		
 }

--- a/relativity/common/edicts/01_planetary_edicts.txt
+++ b/relativity/common/edicts/01_planetary_edicts.txt
@@ -242,7 +242,7 @@ planet_edict = {
 			factor = 0
 			has_resource = {
 				type = energy
-				amount > 15
+				amount < 15
 			}
 		}		
 	}	
@@ -294,7 +294,7 @@ planet_edict = {
 			factor = 0
 			has_resource = {
 				type = minerals
-				amount > 7
+				amount < 7
 			}
 		}
 	}	
@@ -441,6 +441,13 @@ planet_edict = {
 		modifier = {
 			factor = 0
 			num_pops < 10
+		}
+		modifier = {
+			factor = 0
+			has_resource = {
+				type = energy
+				amount < 15
+			}
 		}		
 	}	
 }
@@ -647,8 +654,12 @@ planet_edict = {
 		}
 		modifier = {
 			factor = 0
-			planet_size < 10
-		}			
+			planet_size < 12
+		}
+		modifier = {
+			factor = 5
+			colony_age < 36
+		}
 	}	
 }
 

--- a/relativity/common/policies/00_policies.txt
+++ b/relativity/common/policies/00_policies.txt
@@ -954,6 +954,7 @@ economic_policy = {
 		}		
 		modifier = {
 			tile_resource_energy_mult = 0.25
+			tile_resource_minerals_mult = -0.10
 		}
 		valid = {
 			NOT = {
@@ -1003,6 +1004,10 @@ economic_policy = {
 		}		
 		valid = {
 		}	
+		modifier = {
+			tile_resource_energy_mult = 0.07
+			tile_resource_minerals_mult = 0.07
+		}
 		AI_weight = {
 			modifier = {
 				factor = 10
@@ -1044,6 +1049,7 @@ economic_policy = {
 		}	
 		modifier = {
 			tile_resource_minerals_mult = 0.25
+			tile_resource_energy_mult = -0.10
 		}		
 		pop_happiness = {
 			base = 0
@@ -1102,6 +1108,9 @@ foreign_policy = {
 			has_ethic = "ethic_fanatic_xenophile"
 			}
 		}	
+		modifier = {
+			influence_gain_add = 0.1
+		}
 		pop_happiness = {
 			base = 0
 			modifier = {
@@ -1145,6 +1154,9 @@ foreign_policy = {
 		}		
 		valid = {
 		}	
+		modifier = {
+			max_rivalries = 1
+		}
 		AI_weight = {
 			modifier = {
 				factor = 10
@@ -1182,6 +1194,9 @@ foreign_policy = {
 			has_ethic = "ethic_fanatic_xenophobe"
 			}
 		}	
+		modifier = {
+			max_embassies = 1
+		}
 		pop_happiness = {
 			base = 0
 			modifier = {
@@ -1283,6 +1298,9 @@ religious_policy = {
 		}		
 		valid = {
 		}	
+		modifier = {
+			pop_happiness = 0.1
+		}
 		AI_weight = {
 			modifier = {
 				factor = 10

--- a/relativity/common/ship_sizes/00_ship_sizes.txt
+++ b/relativity/common/ship_sizes/00_ship_sizes.txt
@@ -190,14 +190,14 @@ colonizer = {
 	combat_max_speed = @civilian_ships_combat_speed
 	combat_rotation_speed = 0.2
 	max_hitpoints = 300
-	potential = {
-		owner = {
-			has_monthly_income = {
-				resource = influence
-				value > 0.26
-			}
-		}
-	}
+	#potential = {
+	#	owner = {
+		#	has_monthly_income = {
+		#		resource = influence
+		#		value > 0.26
+	#		}
+	#	}
+	#}
 	modifier = {
 		ship_armor_add = 10
 	}

--- a/relativity/common/ship_sizes/00_ship_sizes.txt
+++ b/relativity/common/ship_sizes/00_ship_sizes.txt
@@ -190,6 +190,14 @@ colonizer = {
 	combat_max_speed = @civilian_ships_combat_speed
 	combat_rotation_speed = 0.2
 	max_hitpoints = 300
+	potential = {
+		owner = {
+			has_monthly_income = {
+				resource = influence
+				value > 0.26
+			}
+		}
+	}
 	modifier = {
 		ship_armor_add = 10
 	}
@@ -200,7 +208,7 @@ colonizer = {
 	is_space_station = no
 	icon_frame = 8
 	base_buildtime = 360
-
+	
 	enable_default_design = yes	#if yes, countries will have an auto-generated design at start
 	prerequisites = { "tech_colonization_1" }
 	is_civilian = yes
@@ -557,6 +565,7 @@ outpost_station = {
     components_add_to_cost = yes
 	
 	enable_default_design = yes	#if yes, countries will have an auto-generated design at start
+	prerequisites = { }
 	class = shipclass_outpost_station
 	required_component_set = "border_extruders"
 	

--- a/relativity/common/spaceport_modules/00_spaceport_modules.txt
+++ b/relativity/common/spaceport_modules/00_spaceport_modules.txt
@@ -135,6 +135,13 @@ observatory = {
 		tile_resource_society_research_mult = 0.1
 		tile_resource_engineering_research_mult = 0.1
 	}
+	ai_weight = {
+		weight = 30
+		modifier = {
+		factor = 0
+		years_passed < 30
+		}
+	}
 }
 
 engineering_bay = {
@@ -156,6 +163,14 @@ engineering_bay = {
 	
 	ship_modifier = {
 		ship_upkeep_mult = -0.10
+	}
+	
+	ai_weight = {
+		weight = 1
+			modifier = {
+				factor = 0
+				years_passed < 60
+			}
 	}
 }
 
@@ -191,6 +206,12 @@ synchronized_defenses = {
 	station_modifier = {
 		ship_fire_rate_mult = 0.25
 		ship_weapon_damage = 0.25
+	}
+	ai_weight = {
+		modifier = {
+		factor = 0
+		years_passed < 60
+		}
 	}
 }
 
@@ -404,8 +425,8 @@ destroyer_assembly_yards = {
 		modifier = {
 			weight = 0
 			OR = {
-				has_technology = tech_spaceport_5
 				has_technology = tech_spaceport_6
+				has_technology = tech_spaceport_7
 			}
 		}
 	}
@@ -443,7 +464,7 @@ pioneering_terminal = {
 	section = "SCIENCE_SPACEPORT_SECTION"
 	construction_days = 360
 	prerequisites = { "tech_frontier_traditions" }	
-	spaceport_level = 3
+	spaceport_level = 2
 	
 	cost = {
 		minerals = 300
@@ -457,6 +478,10 @@ pioneering_terminal = {
 	
 	planet_modifier = {
 			pop_migration_speed = -0.25
+	}
+	
+	ai_weight = {
+		weight = 5
 	}
 }
 

--- a/relativity/common/technology/engineering_strikecraft.txt
+++ b/relativity/common/technology/engineering_strikecraft.txt
@@ -172,7 +172,7 @@ tech_strike_craft_2 = {
 	tier = 3
 	ai_update_type = military
 	category = { voidcraft }	
-	prerequisites = { "tech_strike_craft_1" }
+	prerequisites = { "tech_strike_craft_1" "tech_cold_fusion_power"}
 	weight = @tier3weight1
 	
 	weight_modifier = {
@@ -238,7 +238,7 @@ tech_strike_craft_3 = {
 	tier = 3
 	ai_update_type = military
 	category = { voidcraft }	
-	prerequisites = { "tech_strike_craft_2" }
+	prerequisites = { "tech_strike_craft_2" "tech_antimatter_power"}
 	weight = @tier3weight4
 	
 	weight_modifier = {

--- a/relativity/common/technology/physics_strategic_resources.txt
+++ b/relativity/common/technology/physics_strategic_resources.txt
@@ -418,7 +418,7 @@ tech_mine_betharian = {
 	area = physics
 	tier = 1
 	category = { mining }	
-	prerequisites = { "tech_space_construction" "tech_power_plant_3"}
+	prerequisites = { "tech_sensors_2" "tech_power_plant_3"}
 	weight = @tier1weight3
 	
 	weight_modifier = {

--- a/relativity/common/technology/society_military_theory.txt
+++ b/relativity/common/technology/society_military_theory.txt
@@ -118,10 +118,6 @@ tech_doctrine_fleet_size_1 = {
 	weight_modifier = {
 		factor = 3
 		modifier = {
-			factor = 0
-			
-		}
-		modifier = {
 			factor = 0.65
 			has_ethic = ethic_fanatic_pacifist
 		}


### PR DESCRIPTION
-AI weights work on banks
-More tweaks to both Country and Planetary Edicts AI
-Minor fixes planetary edicts
-Policy Balancing: Economic/Foreign Policy policy options got some new modifiers, fills in blank options
-AI more likely to build Observatories, Engineering Bays, but only after establishing economies
-Pioneering Terminal can be built by level 2 spaceport instead of 3
-AI more likely to build Pioneering Terminal
-AI less likely to build DD assembly yard after researching level 6 and 7 spaceports
-Strikecraft now have reactor prereqs, T2 = Cold Fusion, T3 = Antimatter
-Tech for discovering betharian now requires Sensors 1 and Power Plant 3 instead of space construction.
-Removed rogue factor = 0 that was deactivating naval theory tech line
